### PR TITLE
Can mixin test resets

### DIFF
--- a/dmv.js
+++ b/dmv.js
@@ -51,6 +51,13 @@ exports.getAllNouns = function() {
 exports.getNoun = nouns.get.bind(nouns);
 exports.getRole = roles.get.bind(roles);
 
+/**
+* Empty nouns and roles, resetting dmv. Use with caution.
+*/
+exports.reset = function () {
+  nouns.clear();
+  roles.clear();
+};
 
 setTimeout(function() {
   var entities = Array.from(nouns.values()).concat(Array.from(roles.values()));

--- a/nounManager.js
+++ b/nounManager.js
@@ -8,6 +8,7 @@ class NounManager {
     this.get = this.map.get.bind(this.map);
     this.has = this.map.has.bind(this.map);
     this.values = this.map.values.bind(this.map);
+    this.clear = this.map.clear.bind(this.map);
   }
 }
 

--- a/roleManager.js
+++ b/roleManager.js
@@ -13,6 +13,7 @@ class RoleManager {
     this.get = this.map.get.bind(this.map);
     this.has = this.map.has.bind(this.map);
     this.values = this.map.values.bind(this.map);
+    this.clear = this.map.clear.bind(this.map);
   }
   can(roles, verb, noun) {
     return roles.every(r => this.has(r)) && 

--- a/test/canMixin.test.js
+++ b/test/canMixin.test.js
@@ -16,6 +16,10 @@ describe('canMixin', () => {
     });
   });
 
+  after(() => {
+    dmv.reset();
+  });
+
   describe('can', () => {
     it('is true for something on the whitelist', () => {
       const user = {


### PR DESCRIPTION
@zekenie This uses the new `dmv.reset` to clear `nouns` and `roles` after `canMixin` tests are done. I just tested it and it fixes the issue I was having in `dmv.test.js`.